### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
         steps:
             - uses: actions/checkout@master
             - name: Publish to Registry
-              uses: elgohr/Publish-Docker-Github-Action@v4
+              uses: elgohr/Publish-Docker-Github-Action@v5
               with:
                   registry: ghcr.io
                   name: 'ghcr.io/everlynd/art-pet'


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore